### PR TITLE
Skip over font face type to prevent showing error message in build

### DIFF
--- a/packages/convert-css/CHANGELOG.md
+++ b/packages/convert-css/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.1.3"></a>
+## [0.1.3](https://github.com/projects/breachofmind/repos/oss-projects/compare/diff?targetBranch=refs%2Ftags%2Fconvert-css@0.1.2&sourceBranch=refs%2Ftags%2Fconvert-css@0.1.3) (2019-08-05)
+
+
+### Bug Fixes
+
+* Skip over font face type to prevent showing error message in build ([c1af01b](https://github.com/projects/breachofmind/repos/oss-projects/commits/c1af01b))
+
+
+
+
 <a name="0.1.2"></a>
 ## 0.1.2 (2019-08-05)
 

--- a/packages/convert-css/index.js
+++ b/packages/convert-css/index.js
@@ -68,25 +68,37 @@ const propExists = prop => prop.length;
  */
 function mungeRules(rules) {
   const rulesArr = [];
+
   for (let i = 0; i < rules.length; i += 1) {
     const rule = rules[i];
     const { type } = rule;
-    if (type === 'rule') {
-      const { declarations } = rule;
-      const { selectors } = rule;
-      const ruleObj = {};
-      if (propExists(declarations) && propExists(selectors)) {
-        declarations.forEach(({ property, value }) => {
-          ruleObj[property] = value;
-        });
-        selectors.map(s => ({ [s]: ruleObj })).forEach(r => rulesArr.push(r));
-      }
-    } else if (type === 'media') {
-      rulesArr.concat(mungeRules(rule.rules));
-    } else {
-      console.error(`Type of ${type} did not conform to media or rule \n`, rule);
+
+    switch (type) {
+      case 'rule':
+        const { declarations } = rule;
+        const { selectors } = rule;
+        const ruleObj = {};
+        if (propExists(declarations) && propExists(selectors)) {
+          declarations.forEach(({ property, value }) => {
+            ruleObj[property] = value;
+          });
+          selectors.map(s => ({ [s]: ruleObj })).forEach(r => rulesArr.push(r));
+        }
+        break;
+
+      case 'media':
+        rulesArr.concat(mungeRules(rule.rules));
+        break;
+
+      case 'font-face':
+        // Don't need to alert on this type.
+        break;
+      
+      default:
+        console.error(`Type of ${type} did not conform to media or rule \n`, rule);
     }
   }
+
   return rulesArr;
 }
 

--- a/packages/convert-css/package.json
+++ b/packages/convert-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-css",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Convert css strings to JSON or JS",
   "main": "index.js",
   "author": "David Daniel, <david.daniel@nike.com>",


### PR DESCRIPTION
Fixing an issue where CSS files have `@font-face` declarations and an error message is displayed.
