### PR TITLE
Potential fix for code scanning alert no. 14: Shell command built from environment values

### DIFF
--- a/packages/workspaces-utils/lib/copy-files.js
+++ b/packages/workspaces-utils/lib/copy-files.js
@@ -5,7 +5,7 @@ const { getWorkspaces } = require('./workspaces-paths');
 
 function copyFile(src, dest, { cwd = process.cwd(), logger = console }) {
   logger.info(`Copying ${src} to all ${dest}`);
-  return execa.shell(`${__dirname}/copy.sh ${src} ${dest}`, { stdio: 'inherit', cwd });
+  return execa(path.join(__dirname, 'copy.sh'), [src, dest], { stdio: 'inherit', cwd });
 }
 
 function copyFiles(fromPath, files, projectRoot, logger = console) {


### PR DESCRIPTION
Potential fix for [https://github.com/DavideDaniel/oss-projects/security/code-scanning/14](https://github.com/DavideDaniel/oss-projects/security/code-scanning/14)

To fix the issue, we will replace the use of `execa.shell` with `execa` (or `execa.command`), which allows us to pass the command and its arguments separately. This avoids the need for shell interpretation and ensures that special characters in the arguments are handled safely. Specifically:
1. Replace the dynamically constructed shell command `` `${__dirname}/copy.sh ${src} ${dest}` `` with a command string for the script (`path.join(__dirname, 'copy.sh')`) and an array of arguments (`[src, dest]`).
2. Update the `execa.shell` call to use `execa` with the command and arguments passed separately.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
